### PR TITLE
Deployment: Dockerfile and Smithery config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+# Use an official Node.js image as the base image
+FROM node:20 AS builder
+
+# Set the working directory
+WORKDIR /app
+
+# Copy the package.json and package-lock.json to the working directory
+COPY package.json package-lock.json ./
+
+# Install the dependencies
+RUN npm install
+
+# Copy the rest of the application files to the working directory
+COPY . .
+
+# Build the TypeScript code
+RUN npm run build
+
+# Use a smaller Node.js image for the production environment
+FROM node:20-slim AS production
+
+# Set the working directory
+WORKDIR /app
+
+# Copy the built files and necessary files from the builder stage
+COPY --from=builder /app/build ./build
+COPY --from=builder /app/node_modules ./node_modules
+COPY package.json ./
+
+# Set environment variables (if needed)
+ENV TRANSISTOR_API_KEY=your-api-key-here
+
+# Command to run the application
+ENTRYPOINT ["node", "build/index.js"]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Transistor MCP Server
+[![smithery badge](https://smithery.ai/badge/@gxjansen/Transistor-MCP)](https://smithery.ai/server/@gxjansen/Transistor-MCP)
 
 This MCP server provides tools to interact with the Transistor.fm API, allowing you to manage podcasts, episodes, and view analytics.
 
@@ -400,3 +401,4 @@ const episode = await use_mcp_tool({
   }
 });
 ```
+

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,17 @@
+# Smithery configuration file: https://smithery.ai/docs/deployments
+
+startCommand:
+  type: stdio
+  configSchema:
+    # JSON Schema defining the configuration options for the MCP.
+    type: object
+    required:
+      - transistorApiKey
+    properties:
+      transistorApiKey:
+        type: string
+        description: The API key for the Transistor.fm server.
+  commandFunction:
+    # A function that produces the CLI command to start the MCP on stdio.
+    |-
+    config => ({ command: 'node', args: ['build/index.js'], env: { TRANSISTOR_API_KEY: config.transistorApiKey } })


### PR DESCRIPTION
This pull request introduces the following updates:

- **Dockerfile**: Introduces a Dockerfile to package the MCP for deployment across various environments.
- **Smithery Configuration**: Adds a Smithery YAML file, which specifies how to start the MCP and the configuration options it supports. This file is used by [Smithery](https://smithery.ai?utm_campaign=pr) to render configurations for the end-user. It also allows you to [deploy](https://smithery.ai/docs/deployments) your MCP to Smithery, serving it over SSE so end-users do not need to install additional dependencies. You may deploy your server by visiting your [server page](https://smithery.ai/server/@gxjansen/Transistor-MCP?utm_campaign=pr&modal=claim), claiming it and clicking "Deploy".
- **README**: Updates the README to include a popularity badge.

Please review these updates to verify their accuracy for your server and feel free to customize it to your needs. Let us know if you have any questions. 🙂