### PR TITLE
Merge upstream API-parity improvements + analytics tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,34 +1,24 @@
-# Use an official Node.js image as the base image
-FROM node:20 AS builder
+# transistor-mcp — stdio MCP server for the Transistor.fm podcast hosting API
+# Build:  docker build -t transistor-mcp .
+# Run:    docker run -i --rm -e TRANSISTOR_API_KEY=... transistor-mcp
 
-# Set the working directory
+FROM node:22-alpine AS builder
 WORKDIR /app
+COPY package.json package-lock.json tsconfig.json ./
+COPY src ./src
+RUN npm ci --ignore-scripts && npm run build
 
-# Copy the package.json and package-lock.json to the working directory
+FROM node:22-alpine
+WORKDIR /app
+ENV NODE_ENV=production
 COPY package.json package-lock.json ./
-
-# Install the dependencies
-RUN npm install
-
-# Copy the rest of the application files to the working directory
-COPY . .
-
-# Build the TypeScript code
-RUN npm run build
-
-# Use a smaller Node.js image for the production environment
-FROM node:20-slim AS production
-
-# Set the working directory
-WORKDIR /app
-
-# Copy the built files and necessary files from the builder stage
+RUN npm ci --omit=dev --ignore-scripts
 COPY --from=builder /app/build ./build
-COPY --from=builder /app/node_modules ./node_modules
-COPY package.json ./
 
-# Set environment variables (if needed)
-ENV TRANSISTOR_API_KEY=your-api-key-here
+# Runtime environment variables (optional at startup — the server starts and
+# answers introspection without them; tool calls fail with a clear error
+# until it is set):
+#   TRANSISTOR_API_KEY — API key from https://dashboard.transistor.fm/account
 
-# Command to run the application
-ENTRYPOINT ["node", "build/index.js"]
+USER node
+CMD ["node", "build/index.js"]

--- a/README.md
+++ b/README.md
@@ -189,10 +189,107 @@ Unsubscribe from a webhook.
 }
 ```
 
+### get_show
+Get a show by ID.
+```json
+show_id: string   // Required
+```
+
+### update_show
+Update a show.
+```json
+show_id: string   // Required
+author: string   // Optional
+category: string   // Optional
+copyright: string   // Optional
+description: string   // Optional
+explicit: boolean   // Optional
+image_url: string   // Optional
+keywords: string   // Optional
+language: string   // Optional
+owner_email: string   // Optional
+secondary_category: string   // Optional
+show_type: "episodic" | "serial"   // Optional
+title: string   // Optional
+time_zone: string   // Optional
+website: string   // Optional
+```
+
+### publish_episode
+Publish or schedule an episode without otherwise editing its metadata.
+```json
+episode_id: string   // Required
+status: "published" | "scheduled" | "draft"   // Required
+published_at: string   // Optional
+```
+
+### get_download_summary
+Get a computed download summary for a show or episode. Returns total downloads, daily average, week-over-week trend, and best/worst day.
+```json
+show_id: string   // Required
+episode_id: string   // Optional
+start_date: string   // Optional
+end_date: string   // Optional
+```
+
+### compare_episodes
+Compare download performance across multiple episodes, sorted by total downloads.
+```json
+episode_ids: string[]   // Required - array of episode IDs
+start_date: string   // Optional
+end_date: string   // Optional
+```
+
+### list_subscribers
+List subscribers for a show.
+```json
+show_id: string   // Required
+page: number   // Optional
+per: number   // Optional
+query: string   // Optional
+```
+
+### get_subscriber
+Get a subscriber by ID.
+```json
+subscriber_id: string   // Required
+```
+
+### create_subscriber
+Create a subscriber.
+```json
+show_id: string   // Required
+email: string   // Required
+skip_welcome_email: boolean   // Optional
+```
+
+### create_subscribers_batch
+Create multiple subscribers in a single request.
+```json
+show_id: string   // Required
+emails: string[]   // Required
+skip_welcome_email: boolean   // Optional
+```
+
+### update_subscriber
+Update a subscriber's email.
+```json
+subscriber_id: string   // Required
+email: string   // Required
+```
+
+### delete_subscriber
+Delete a subscriber. Provide either `subscriber_id`, OR both `show_id` and `email`.
+```json
+subscriber_id: string   // Optional - either this, or both show_id + email
+show_id: string   // Optional - required with email when no subscriber_id
+email: string   // Optional - required with show_id when no subscriber_id
+```
+
 ## Important Notes
 
 - API requests are rate-limited to 10 requests per 10 seconds (as prescribed by the (https://developers.transistor.fm/#:~:text=API%20requests%20are%20rate%2Dlimited,to%20use%20the%20API%20again.)[Transistor API reference])
-- Dates must be in "dd-mm-yyyy" format
+- Dates accept ISO `yyyy-mm-dd` (recommended) and are converted to the Transistor API's `dd-mm-yyyy` automatically; `dd-mm-yyyy` is also accepted
 - Page numbers start at 0
 - All endpoints support:
   - Sparse fieldsets: Specify which fields to return using `fields[resource_type][]`
@@ -380,14 +477,8 @@ const episode = await use_mcp_tool({
 });
 ```
 
-## Not Yet Implemented
+## Coverage
 
-The following Transistor API features are not yet implemented:
-- Private Episodes functionality (subscribers management)
-  - GET /v1/subscribers
-  - GET /v1/subscribers/:id
-  - POST /v1/subscribers
-  - POST /v1/subscribers/batch
-  - PATCH /v1/subscribers/:id
-  - DELETE /v1/subscribers
-  - DELETE /v1/subscribers/:id
+This server now covers the full documented Transistor API surface, including shows,
+episodes, analytics, download summaries, webhooks, and private-podcast subscriber
+management (`GET/POST/PATCH/DELETE /v1/subscribers`).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "transistor-server",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "transistor-server",
-      "version": "0.1.0",
+      "version": "0.2.0",
+      "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "0.6.0",
         "axios": "^1.7.9"
@@ -17,6 +18,9 @@
       "devDependencies": {
         "@types/node": "^20.11.24",
         "typescript": "^5.3.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {

--- a/package.json
+++ b/package.json
@@ -1,9 +1,33 @@
 {
   "name": "transistor-server",
-  "version": "0.1.0",
-  "description": "Transistor.fm API integration",
+  "version": "0.2.0",
+  "description": "MCP server for the Transistor.fm podcast hosting API — manage shows, episodes, analytics, download summaries, transcripts, subscribers, and webhooks.",
   "private": true,
   "type": "module",
+  "author": "Guido X Jansen (https://github.com/gxjansen)",
+  "contributors": [
+    "Conor Bronsdon (https://conorbronsdon.com)"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/gxjansen/Transistor-MCP.git"
+  },
+  "homepage": "https://github.com/gxjansen/Transistor-MCP#readme",
+  "bugs": {
+    "url": "https://github.com/gxjansen/Transistor-MCP/issues"
+  },
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "transistor",
+    "transistor-fm",
+    "podcast",
+    "podcast-hosting",
+    "analytics",
+    "claude",
+    "ai-agents"
+  ],
   "bin": {
     "transistor-server": "./build/index.js"
   },
@@ -13,6 +37,7 @@
   "scripts": {
     "build": "node --max-old-space-size=4096 ./node_modules/.bin/tsc && node -e \"require('fs').chmodSync('build/index.js', '755')\"",
     "prepare": "npm run build",
+    "lint": "tsc --noEmit",
     "watch": "tsc --watch"
   },
   "dependencies": {
@@ -22,5 +47,8 @@
   "devDependencies": {
     "@types/node": "^20.11.24",
     "typescript": "^5.3.3"
+  },
+  "engines": {
+    "node": ">=18.0.0"
   }
 }

--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -11,7 +11,17 @@ import {
   ListWebhooksArgs,
   SubscribeWebhookArgs,
   UnsubscribeWebhookArgs,
+  PublishEpisodeArgs,
+  GetShowArgs,
+  UpdateShowArgs,
+  ListSubscribersArgs,
+  GetSubscriberArgs,
+  CreateSubscriberArgs,
+  CreateSubscribersBatchArgs,
+  UpdateSubscriberArgs,
+  DeleteSubscriberArgs,
 } from "./types.js";
+import { toTransistorDate } from "./date-utils.js";
 
 export class TransistorApiClient {
   private api: AxiosInstance;
@@ -39,24 +49,40 @@ export class TransistorApiClient {
   }
 
   async listShows(args: ListShowsArgs) {
-    const { page = 1 } = args;
-    const response = await this.api.get("/v1/shows", {
-      params: { "pagination[page]": page, "pagination[per]": 10 },
-    });
+    const { page = 1, per = 10, query } = args;
+    const params: Record<string, string | number | boolean> = {
+      "pagination[page]": page,
+      "pagination[per]": per,
+    };
+    if (query) params.query = query;
+    if (args.private !== undefined) params.private = args.private;
+    const response = await this.api.get("/v1/shows", { params });
     return response.data;
   }
 
   async listEpisodes(args: ListEpisodesArgs) {
-    const { show_id, page = 1, status } = args;
-    const response = await this.api.get("/v1/episodes", {
-      params: { show_id, "pagination[page]": page, "pagination[per]": 10, status },
-    });
+    const { show_id, page = 1, per = 10, query, status, order, fields } = args;
+    const params: Record<string, string | number | string[]> = {
+      show_id,
+      "pagination[page]": page,
+      "pagination[per]": per,
+    };
+    if (status) params.status = status;
+    if (query) params.query = query;
+    if (order) params.order = order;
+    if (fields) {
+      for (const [resource, fieldList] of Object.entries(fields)) {
+        params[`fields[${resource}]`] = fieldList.join(",");
+      }
+    }
+    const response = await this.api.get("/v1/episodes", { params });
     return response.data;
   }
 
   async createEpisode(args: CreateEpisodeArgs) {
+    const { show_id, ...episodeData } = args;
     const response = await this.api.post("/v1/episodes", {
-      episode: args,
+      episode: { show_id, ...episodeData },
     });
     return response.data;
   }
@@ -74,16 +100,24 @@ export class TransistorApiClient {
     const endpoint = episode_id
       ? `/v1/analytics/episodes/${episode_id}`
       : `/v1/analytics/${show_id}`;
-    const response = await this.api.get(endpoint, {
-      params: { start_date, end_date },
-    });
+    const params: Record<string, string> = {};
+    const convertedStart = toTransistorDate(start_date);
+    const convertedEnd = toTransistorDate(end_date);
+    if (convertedStart) params.start_date = convertedStart;
+    if (convertedEnd) params.end_date = convertedEnd;
+    const response = await this.api.get(endpoint, { params });
     return response.data;
   }
 
   async getAllEpisodeAnalytics(args: GetAllEpisodeAnalyticsArgs) {
     const { show_id, start_date, end_date } = args;
+    const params: Record<string, string> = {};
+    const convertedStart = toTransistorDate(start_date);
+    const convertedEnd = toTransistorDate(end_date);
+    if (convertedStart) params.start_date = convertedStart;
+    if (convertedEnd) params.end_date = convertedEnd;
     const response = await this.api.get(`/v1/analytics/${show_id}/episodes`, {
-      params: { start_date, end_date },
+      params,
     });
     return response.data;
   }
@@ -120,6 +154,87 @@ export class TransistorApiClient {
     }
     const response = await this.api.get(`/v1/episodes/${episode_id}`, {
       params,
+    });
+    return response.data;
+  }
+
+  async publishEpisode(args: PublishEpisodeArgs) {
+    const { episode_id, status, published_at } = args;
+    const episode: Record<string, string> = { status };
+    if (published_at) episode.published_at = published_at;
+    const response = await this.api.patch(
+      `/v1/episodes/${episode_id}/publish`,
+      { episode }
+    );
+    return response.data;
+  }
+
+  async getShow(args: GetShowArgs) {
+    const response = await this.api.get(`/v1/shows/${args.show_id}`);
+    return response.data;
+  }
+
+  async updateShow(args: UpdateShowArgs) {
+    const { show_id, ...showData } = args;
+    const response = await this.api.patch(`/v1/shows/${show_id}`, {
+      show: showData,
+    });
+    return response.data;
+  }
+
+  async listSubscribers(args: ListSubscribersArgs) {
+    const { show_id, page = 1, per = 10, query } = args;
+    const params: Record<string, string | number> = {
+      show_id,
+      "pagination[page]": page,
+      "pagination[per]": per,
+    };
+    if (query) params.query = query;
+    const response = await this.api.get("/v1/subscribers", { params });
+    return response.data;
+  }
+
+  async getSubscriber(args: GetSubscriberArgs) {
+    const response = await this.api.get(
+      `/v1/subscribers/${args.subscriber_id}`
+    );
+    return response.data;
+  }
+
+  async createSubscriber(args: CreateSubscriberArgs) {
+    const response = await this.api.post("/v1/subscribers", args);
+    return response.data;
+  }
+
+  async createSubscribersBatch(args: CreateSubscribersBatchArgs) {
+    const response = await this.api.post("/v1/subscribers/batch", args);
+    return response.data;
+  }
+
+  async updateSubscriber(args: UpdateSubscriberArgs) {
+    const { subscriber_id, email } = args;
+    const response = await this.api.patch(
+      `/v1/subscribers/${subscriber_id}`,
+      { subscriber: { email } }
+    );
+    return response.data;
+  }
+
+  async deleteSubscriber(args: DeleteSubscriberArgs) {
+    if (args.subscriber_id) {
+      const response = await this.api.delete(
+        `/v1/subscribers/${args.subscriber_id}`
+      );
+      return response.data;
+    }
+    // Delete by show_id + email — both are required for this branch.
+    if (!args.show_id || !args.email) {
+      throw new Error(
+        "delete_subscriber requires either subscriber_id, or both show_id and email."
+      );
+    }
+    const response = await this.api.delete("/v1/subscribers", {
+      params: { show_id: args.show_id, email: args.email },
     });
     return response.data;
   }

--- a/src/date-utils.ts
+++ b/src/date-utils.ts
@@ -1,0 +1,68 @@
+/**
+ * Date format utilities for the Transistor API.
+ *
+ * The Transistor API expects dates in dd-mm-yyyy format, but ISO yyyy-mm-dd
+ * is far more natural for LLMs and less error-prone. These helpers detect
+ * which format was provided and convert to the API's expected format.
+ */
+
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+const TRANSISTOR_DATE_RE = /^\d{2}-\d{2}-\d{4}$/;
+
+/**
+ * Verify that y/m/d form a real calendar date (e.g. reject 2025-13-40 or
+ * 2025-02-30). Returns true only when the numbers round-trip through Date.
+ */
+function isRealDate(year: number, month: number, day: number): boolean {
+  if (month < 1 || month > 12 || day < 1 || day > 31) return false;
+  const d = new Date(Date.UTC(year, month - 1, day));
+  return (
+    d.getUTCFullYear() === year &&
+    d.getUTCMonth() === month - 1 &&
+    d.getUTCDate() === day
+  );
+}
+
+/**
+ * Convert a date string to Transistor's dd-mm-yyyy format.
+ * Accepts either ISO (yyyy-mm-dd) or already-correct (dd-mm-yyyy).
+ * Returns undefined for undefined input.
+ * Throws on a syntactically-ISO string that is not a real calendar date.
+ */
+export function toTransistorDate(date: string | undefined): string | undefined {
+  if (!date) return undefined;
+
+  if (ISO_DATE_RE.test(date)) {
+    const [year, month, day] = date.split("-").map(Number);
+    if (!isRealDate(year, month, day)) {
+      throw new Error(
+        `Invalid date "${date}": expected a real calendar date in yyyy-mm-dd format.`
+      );
+    }
+    const [y, m, d] = date.split("-");
+    return `${d}-${m}-${y}`;
+  }
+
+  if (TRANSISTOR_DATE_RE.test(date)) {
+    // Already in Transistor dd-mm-yyyy format (ambiguous: dd-mm vs mm-dd is
+    // not validated here — passed through and resolved server-side).
+    return date;
+  }
+
+  // Unknown format — pass through and let the API reject if invalid
+  return date;
+}
+
+/**
+ * Convert a Transistor dd-mm-yyyy date string to ISO yyyy-mm-dd.
+ */
+export function toIsoDate(date: string): string {
+  if (ISO_DATE_RE.test(date)) return date;
+
+  if (TRANSISTOR_DATE_RE.test(date)) {
+    const [day, month, year] = date.split("-");
+    return `${year}-${month}-${day}`;
+  }
+
+  return date;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,9 +8,14 @@ import {
 import { TransistorApiClient } from "./api-client.js";
 import { ToolHandlers } from "./tool-handlers.js";
 
-const API_KEY = process.env.TRANSISTOR_API_KEY;
+const API_KEY = process.env.TRANSISTOR_API_KEY ?? "";
 if (!API_KEY) {
-  throw new Error("TRANSISTOR_API_KEY environment variable is required");
+  console.error(
+    "Warning: TRANSISTOR_API_KEY is not set. The server will start, but tool calls will fail until it is configured."
+  );
+  console.error(
+    "Get your API key at https://dashboard.transistor.fm/account. See README.md."
+  );
 }
 
 class TransistorServer {
@@ -30,8 +35,8 @@ class TransistorServer {
       }
     );
 
-    const apiClient = new TransistorApiClient(API_KEY as string);
-    this.toolHandlers = new ToolHandlers(apiClient);
+    const apiClient = new TransistorApiClient(API_KEY);
+    this.toolHandlers = new ToolHandlers(apiClient, Boolean(API_KEY));
 
     this.setupToolHandlers();
 

--- a/src/tool-handlers.ts
+++ b/src/tool-handlers.ts
@@ -13,12 +13,68 @@ import {
   isUnsubscribeWebhookArgs,
   isGetAuthenticatedUserArgs,
   isAuthorizeUploadArgs,
+  isGetDownloadSummaryArgs,
+  isCompareEpisodesArgs,
+  isPublishEpisodeArgs,
+  isGetShowArgs,
+  isUpdateShowArgs,
+  isListSubscribersArgs,
+  isGetSubscriberArgs,
+  isCreateSubscriberArgs,
+  isCreateSubscribersBatchArgs,
+  isUpdateSubscriberArgs,
+  isDeleteSubscriberArgs,
   AuthorizeUploadArgs,
+  GetDownloadSummaryArgs,
+  CompareEpisodesArgs,
 } from "./types.js";
+import { toIsoDate } from "./date-utils.js";
 import axios from "axios";
 
+/**
+ * Extract a concise, human-readable message from an unknown thrown value,
+ * preferring the Transistor API's status/message when it is an Axios error.
+ */
+function errorMessage(e: unknown): string {
+  if (axios.isAxiosError(e)) {
+    const status = e.response?.status;
+    const apiMsg =
+      (e.response?.data as { error?: string } | undefined)?.error ?? e.message;
+    return status ? `HTTP ${status}: ${apiMsg}` : apiMsg;
+  }
+  return e instanceof Error ? e.message : String(e);
+}
+
+/**
+ * Strip heavy fields from episode responses to reduce token usage.
+ * Removes HTML descriptions, embed codes, and formatted variants
+ * that are rarely needed by the caller.
+ */
+function trimEpisodeResponse(data: any): any {
+  if (!data?.data) return data;
+
+  const strip = (attrs: any) => {
+    if (!attrs) return;
+    delete attrs.formatted_description;
+    delete attrs.formatted_summary;
+    delete attrs.embed_html;
+    delete attrs.embed_html_dark;
+    // Keep description and summary since callers may need them
+  };
+
+  if (Array.isArray(data.data)) {
+    for (const ep of data.data) strip(ep?.attributes);
+  } else {
+    strip(data.data?.attributes);
+  }
+  return data;
+}
+
 export class ToolHandlers {
-  constructor(private apiClient: TransistorApiClient) {}
+  constructor(
+    private apiClient: TransistorApiClient,
+    private hasCredentials: boolean = true
+  ) {}
 
   getToolDefinitions() {
     return [
@@ -27,7 +83,7 @@ export class ToolHandlers {
         description: "Get details of the authenticated user account",
         inputSchema: {
           type: "object",
-          properties: {},  // No parameters needed
+          properties: {},
         },
       },
       {
@@ -55,12 +111,27 @@ export class ToolHandlers {
               description: "Page number for pagination",
               minimum: 1,
             },
+            per: {
+              type: "number",
+              description: "Items per page (default 10, max 100)",
+              minimum: 1,
+              maximum: 100,
+            },
+            private: {
+              type: "boolean",
+              description: "Filter for private shows",
+            },
+            query: {
+              type: "string",
+              description: "Search query to filter shows",
+            },
           },
         },
       },
       {
         name: "list_episodes",
-        description: "List episodes for a specific show",
+        description:
+          "List episodes for a specific show. Use 'fields' to request only specific attributes and reduce response size (e.g. {\"episode\": [\"title\", \"number\", \"status\", \"season\"]}). Use 'query' to search by title.",
         inputSchema: {
           type: "object",
           properties: {
@@ -73,10 +144,31 @@ export class ToolHandlers {
               description: "Page number for pagination",
               minimum: 1,
             },
+            per: {
+              type: "number",
+              description: "Items per page (default 10, max 100)",
+              minimum: 1,
+              maximum: 100,
+            },
+            query: {
+              type: "string",
+              description: "Search episodes by title",
+            },
             status: {
               type: "string",
               enum: ["published", "draft", "scheduled"],
               description: "Filter episodes by status",
+            },
+            order: {
+              type: "string",
+              enum: ["asc", "desc"],
+              description:
+                "Sort order: 'desc' (newest first, default) or 'asc' (oldest first)",
+            },
+            fields: {
+              type: "object",
+              description:
+                "Sparse fieldsets to reduce response size. Keys are resource types (e.g. 'episode'), values are arrays of field names (e.g. ['title', 'number', 'status', 'season', 'transcript_url'])",
             },
           },
           required: ["show_id"],
@@ -96,6 +188,10 @@ export class ToolHandlers {
               type: "string",
               description: "Episode title",
             },
+            audio_url: {
+              type: "string",
+              description: "URL to the episode audio file",
+            },
             summary: {
               type: "string",
               description: "Episode summary",
@@ -104,22 +200,59 @@ export class ToolHandlers {
               type: "string",
               description: "Episode description (supports HTML)",
             },
-            status: {
+            transcript_text: {
               type: "string",
-              enum: ["published", "draft", "scheduled"],
-              description: "Episode status",
+              description: "Plain text transcript for the episode",
+            },
+            author: {
+              type: "string",
+              description: "Episode author name",
+            },
+            explicit: {
+              type: "boolean",
+              description: "Whether the episode contains explicit content",
+            },
+            image_url: {
+              type: "string",
+              description: "URL to episode artwork",
+            },
+            keywords: {
+              type: "string",
+              description: "Comma-separated list of keywords",
+            },
+            number: {
+              type: "number",
+              description: "Episode number",
             },
             season_number: {
               type: "number",
               description: "Season number",
             },
-            episode_number: {
-              type: "number",
-              description: "Episode number",
-            },
-            audio_url: {
+            type: {
               type: "string",
-              description: "URL to the episode audio file",
+              enum: ["full", "trailer", "bonus"],
+              description: "Episode type",
+            },
+            alternate_url: {
+              type: "string",
+              description: "Override the default share URL",
+            },
+            video_url: {
+              type: "string",
+              description: "YouTube or video URL",
+            },
+            email_notifications: {
+              type: "boolean",
+              description: "Override show email notification setting",
+            },
+            increment_number: {
+              type: "boolean",
+              description: "Auto-set next episode number",
+            },
+            status: {
+              type: "string",
+              enum: ["published", "draft", "scheduled"],
+              description: "Episode status",
             },
           },
           required: ["show_id", "title", "audio_url"],
@@ -147,10 +280,29 @@ export class ToolHandlers {
               type: "string",
               description: "New episode description (supports HTML)",
             },
-            status: {
+            transcript_text: {
               type: "string",
-              enum: ["published", "draft", "scheduled"],
-              description: "New episode status",
+              description: "Plain text transcript for the episode",
+            },
+            author: {
+              type: "string",
+              description: "Episode author name",
+            },
+            explicit: {
+              type: "boolean",
+              description: "Whether the episode contains explicit content",
+            },
+            image_url: {
+              type: "string",
+              description: "URL to episode artwork",
+            },
+            keywords: {
+              type: "string",
+              description: "Comma-separated list of keywords",
+            },
+            number: {
+              type: "number",
+              description: "Episode number",
             },
             season_number: {
               type: "number",
@@ -158,7 +310,29 @@ export class ToolHandlers {
             },
             episode_number: {
               type: "number",
-              description: "New episode number",
+              description: "New episode number (alias for number)",
+            },
+            type: {
+              type: "string",
+              enum: ["full", "trailer", "bonus"],
+              description: "Episode type",
+            },
+            alternate_url: {
+              type: "string",
+              description: "Override the default share URL",
+            },
+            video_url: {
+              type: "string",
+              description: "YouTube or video URL",
+            },
+            email_notifications: {
+              type: "boolean",
+              description: "Override show email notification setting",
+            },
+            status: {
+              type: "string",
+              enum: ["published", "draft", "scheduled"],
+              description: "New episode status",
             },
           },
           required: ["episode_id"],
@@ -166,7 +340,8 @@ export class ToolHandlers {
       },
       {
         name: "get_analytics",
-        description: "Get analytics for a show or episode",
+        description:
+          "Get analytics for a show or episode. Defaults to last 14 days if no dates provided.",
         inputSchema: {
           type: "object",
           properties: {
@@ -176,18 +351,19 @@ export class ToolHandlers {
             },
             episode_id: {
               type: "string",
-              description: "ID of the episode to get analytics for (optional)",
+              description:
+                "ID of the episode to get analytics for (optional)",
             },
             start_date: {
               type: "string",
-              description: "Start date in YYYY-MM-DD format",
+              description: "Start date (accepts yyyy-mm-dd or dd-mm-yyyy) (optional)",
             },
             end_date: {
               type: "string",
-              description: "End date in YYYY-MM-DD format",
+              description: "End date (accepts yyyy-mm-dd or dd-mm-yyyy) (optional)",
             },
           },
-          required: ["show_id", "start_date", "end_date"],
+          required: ["show_id"],
         },
       },
       {
@@ -217,7 +393,8 @@ export class ToolHandlers {
       },
       {
         name: "get_all_episode_analytics",
-        description: "Get analytics for all episodes of a show",
+        description:
+          "Get analytics for all episodes of a show. Defaults to last 7 days if no dates provided.",
         inputSchema: {
           type: "object",
           properties: {
@@ -227,14 +404,14 @@ export class ToolHandlers {
             },
             start_date: {
               type: "string",
-              description: "Start date in dd-mm-yyyy format",
+              description: "Start date (accepts yyyy-mm-dd or dd-mm-yyyy) (optional)",
             },
             end_date: {
               type: "string",
-              description: "End date in dd-mm-yyyy format",
+              description: "End date (accepts yyyy-mm-dd or dd-mm-yyyy) (optional)",
             },
           },
-          required: ["show_id", "start_date", "end_date"],
+          required: ["show_id"],
         },
       },
       {
@@ -287,10 +464,310 @@ export class ToolHandlers {
           required: ["webhook_id"],
         },
       },
+      {
+        name: "get_download_summary",
+        description:
+          "Get a computed download summary for a show or episode. Returns total downloads, daily average, week-over-week trend, and best/worst days — no manual calculation needed.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            show_id: {
+              type: "string",
+              description: "ID of the show",
+            },
+            episode_id: {
+              type: "string",
+              description: "ID of a specific episode (optional, omit for show-level stats)",
+            },
+            start_date: {
+              type: "string",
+              description: "Start date (accepts yyyy-mm-dd or dd-mm-yyyy) (optional)",
+            },
+            end_date: {
+              type: "string",
+              description: "End date (accepts yyyy-mm-dd or dd-mm-yyyy) (optional)",
+            },
+          },
+          required: ["show_id"],
+        },
+      },
+      {
+        name: "compare_episodes",
+        description:
+          "Compare download performance across 2 or more episodes. Returns side-by-side stats: total downloads, daily average, peak day, and days since publish for each episode.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            episode_ids: {
+              type: "array",
+              items: { type: "string" },
+              minItems: 2,
+              description: "Array of episode IDs to compare (minimum 2)",
+            },
+            start_date: {
+              type: "string",
+              description: "Start date (accepts yyyy-mm-dd or dd-mm-yyyy) (optional)",
+            },
+            end_date: {
+              type: "string",
+              description: "End date (accepts yyyy-mm-dd or dd-mm-yyyy) (optional)",
+            },
+          },
+          required: ["episode_ids"],
+        },
+      },
+      {
+        name: "publish_episode",
+        description:
+          "Publish, schedule, or unpublish an episode. Use this to change an episode's publish status separately from updating its metadata.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            episode_id: {
+              type: "string",
+              description: "ID of the episode",
+            },
+            status: {
+              type: "string",
+              enum: ["published", "scheduled", "draft"],
+              description:
+                "New status: 'published' to publish now, 'scheduled' to schedule for a future date, 'draft' to unpublish",
+            },
+            published_at: {
+              type: "string",
+              description:
+                "Date/time to publish or schedule (in the podcast's time zone). Required when status is 'scheduled'.",
+            },
+          },
+          required: ["episode_id", "status"],
+        },
+      },
+      {
+        name: "get_show",
+        description: "Get details of a single show by ID",
+        inputSchema: {
+          type: "object",
+          properties: {
+            show_id: {
+              type: "string",
+              description: "ID of the show",
+            },
+          },
+          required: ["show_id"],
+        },
+      },
+      {
+        name: "update_show",
+        description: "Update a show's metadata",
+        inputSchema: {
+          type: "object",
+          properties: {
+            show_id: {
+              type: "string",
+              description: "ID of the show to update",
+            },
+            author: {
+              type: "string",
+              description: "Show author name",
+            },
+            category: {
+              type: "string",
+              description: "Primary podcast category",
+            },
+            copyright: {
+              type: "string",
+              description: "Copyright notice",
+            },
+            description: {
+              type: "string",
+              description: "Show description",
+            },
+            explicit: {
+              type: "boolean",
+              description: "Whether the show contains explicit content",
+            },
+            image_url: {
+              type: "string",
+              description: "URL to show artwork",
+            },
+            keywords: {
+              type: "string",
+              description: "Comma-separated keywords",
+            },
+            language: {
+              type: "string",
+              description: "Show language (e.g. 'en')",
+            },
+            owner_email: {
+              type: "string",
+              description: "Owner email address",
+            },
+            secondary_category: {
+              type: "string",
+              description: "Secondary podcast category",
+            },
+            show_type: {
+              type: "string",
+              enum: ["episodic", "serial"],
+              description: "Show type",
+            },
+            title: {
+              type: "string",
+              description: "Show title",
+            },
+            time_zone: {
+              type: "string",
+              description: "Time zone for the show",
+            },
+            website: {
+              type: "string",
+              description: "Show website URL",
+            },
+          },
+          required: ["show_id"],
+        },
+      },
+      {
+        name: "list_subscribers",
+        description:
+          "List subscribers for a private podcast. Returns a paginated list.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            show_id: {
+              type: "string",
+              description: "ID of the private podcast",
+            },
+            page: {
+              type: "number",
+              description: "Page number for pagination",
+              minimum: 1,
+            },
+            per: {
+              type: "number",
+              description: "Items per page (default 10)",
+              minimum: 1,
+            },
+            query: {
+              type: "string",
+              description: "Search query to filter subscribers",
+            },
+          },
+          required: ["show_id"],
+        },
+      },
+      {
+        name: "get_subscriber",
+        description: "Get details of a single subscriber",
+        inputSchema: {
+          type: "object",
+          properties: {
+            subscriber_id: {
+              type: "string",
+              description: "ID of the subscriber",
+            },
+          },
+          required: ["subscriber_id"],
+        },
+      },
+      {
+        name: "create_subscriber",
+        description: "Add a subscriber to a private podcast",
+        inputSchema: {
+          type: "object",
+          properties: {
+            show_id: {
+              type: "string",
+              description: "ID of the private podcast",
+            },
+            email: {
+              type: "string",
+              description: "Subscriber email address",
+            },
+            skip_welcome_email: {
+              type: "boolean",
+              description: "Skip sending welcome email (default false)",
+            },
+          },
+          required: ["show_id", "email"],
+        },
+      },
+      {
+        name: "create_subscribers_batch",
+        description: "Add multiple subscribers to a private podcast at once",
+        inputSchema: {
+          type: "object",
+          properties: {
+            show_id: {
+              type: "string",
+              description: "ID of the private podcast",
+            },
+            emails: {
+              type: "array",
+              items: { type: "string" },
+              description: "Array of subscriber email addresses",
+            },
+            skip_welcome_email: {
+              type: "boolean",
+              description: "Skip sending welcome emails (default false)",
+            },
+          },
+          required: ["show_id", "emails"],
+        },
+      },
+      {
+        name: "update_subscriber",
+        description: "Update a subscriber's email address",
+        inputSchema: {
+          type: "object",
+          properties: {
+            subscriber_id: {
+              type: "string",
+              description: "ID of the subscriber to update",
+            },
+            email: {
+              type: "string",
+              description: "New email address",
+            },
+          },
+          required: ["subscriber_id", "email"],
+        },
+      },
+      {
+        name: "delete_subscriber",
+        description:
+          "Delete a subscriber by ID or by show_id + email. Provide either subscriber_id alone, or both show_id and email.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            subscriber_id: {
+              type: "string",
+              description: "ID of the subscriber to delete",
+            },
+            show_id: {
+              type: "string",
+              description:
+                "ID of the show (use with email instead of subscriber_id)",
+            },
+            email: {
+              type: "string",
+              description:
+                "Email of the subscriber to delete (use with show_id instead of subscriber_id)",
+            },
+          },
+        },
+      },
     ];
   }
 
   async handleToolCall(name: string, args: unknown) {
+    if (!this.hasCredentials) {
+      throw new McpError(
+        ErrorCode.InvalidRequest,
+        "TRANSISTOR_API_KEY environment variable is required. " +
+          "Get your API key at https://dashboard.transistor.fm/account, set it, and restart the server."
+      );
+    }
     try {
       switch (name) {
         case "get_authenticated_user": {
@@ -340,8 +817,11 @@ export class ToolHandlers {
             );
           }
           const data = await this.apiClient.listEpisodes(args);
+          const trimmed = trimEpisodeResponse(data);
           return {
-            content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+            content: [
+              { type: "text", text: JSON.stringify(trimmed, null, 2) },
+            ],
           };
         }
 
@@ -353,8 +833,11 @@ export class ToolHandlers {
             );
           }
           const data = await this.apiClient.createEpisode(args);
+          const trimmed = trimEpisodeResponse(data);
           return {
-            content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+            content: [
+              { type: "text", text: JSON.stringify(trimmed, null, 2) },
+            ],
           };
         }
 
@@ -366,8 +849,11 @@ export class ToolHandlers {
             );
           }
           const data = await this.apiClient.updateEpisode(args);
+          const trimmed = trimEpisodeResponse(data);
           return {
-            content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+            content: [
+              { type: "text", text: JSON.stringify(trimmed, null, 2) },
+            ],
           };
         }
 
@@ -449,6 +935,160 @@ export class ToolHandlers {
           };
         }
 
+        case "get_download_summary": {
+          if (!isGetDownloadSummaryArgs(args)) {
+            throw new McpError(
+              ErrorCode.InvalidParams,
+              "Invalid arguments for get_download_summary"
+            );
+          }
+          const summary = await this.computeDownloadSummary(
+            args as GetDownloadSummaryArgs
+          );
+          return {
+            content: [
+              { type: "text", text: JSON.stringify(summary, null, 2) },
+            ],
+          };
+        }
+
+        case "compare_episodes": {
+          if (!isCompareEpisodesArgs(args)) {
+            throw new McpError(
+              ErrorCode.InvalidParams,
+              "Invalid arguments for compare_episodes (need at least 2 episode_ids)"
+            );
+          }
+          const comparison = await this.computeEpisodeComparison(
+            args as CompareEpisodesArgs
+          );
+          return {
+            content: [
+              { type: "text", text: JSON.stringify(comparison, null, 2) },
+            ],
+          };
+        }
+
+        case "publish_episode": {
+          if (!isPublishEpisodeArgs(args)) {
+            throw new McpError(
+              ErrorCode.InvalidParams,
+              "Invalid arguments for publish_episode"
+            );
+          }
+          const data = await this.apiClient.publishEpisode(args);
+          const trimmed = trimEpisodeResponse(data);
+          return {
+            content: [
+              { type: "text", text: JSON.stringify(trimmed, null, 2) },
+            ],
+          };
+        }
+
+        case "get_show": {
+          if (!isGetShowArgs(args)) {
+            throw new McpError(
+              ErrorCode.InvalidParams,
+              "Invalid arguments for get_show"
+            );
+          }
+          const data = await this.apiClient.getShow(args);
+          return {
+            content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+          };
+        }
+
+        case "update_show": {
+          if (!isUpdateShowArgs(args)) {
+            throw new McpError(
+              ErrorCode.InvalidParams,
+              "Invalid arguments for update_show"
+            );
+          }
+          const data = await this.apiClient.updateShow(args);
+          return {
+            content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+          };
+        }
+
+        case "list_subscribers": {
+          if (!isListSubscribersArgs(args)) {
+            throw new McpError(
+              ErrorCode.InvalidParams,
+              "Invalid arguments for list_subscribers"
+            );
+          }
+          const data = await this.apiClient.listSubscribers(args);
+          return {
+            content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+          };
+        }
+
+        case "get_subscriber": {
+          if (!isGetSubscriberArgs(args)) {
+            throw new McpError(
+              ErrorCode.InvalidParams,
+              "Invalid arguments for get_subscriber"
+            );
+          }
+          const data = await this.apiClient.getSubscriber(args);
+          return {
+            content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+          };
+        }
+
+        case "create_subscriber": {
+          if (!isCreateSubscriberArgs(args)) {
+            throw new McpError(
+              ErrorCode.InvalidParams,
+              "Invalid arguments for create_subscriber"
+            );
+          }
+          const data = await this.apiClient.createSubscriber(args);
+          return {
+            content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+          };
+        }
+
+        case "create_subscribers_batch": {
+          if (!isCreateSubscribersBatchArgs(args)) {
+            throw new McpError(
+              ErrorCode.InvalidParams,
+              "Invalid arguments for create_subscribers_batch"
+            );
+          }
+          const data = await this.apiClient.createSubscribersBatch(args);
+          return {
+            content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+          };
+        }
+
+        case "update_subscriber": {
+          if (!isUpdateSubscriberArgs(args)) {
+            throw new McpError(
+              ErrorCode.InvalidParams,
+              "Invalid arguments for update_subscriber"
+            );
+          }
+          const data = await this.apiClient.updateSubscriber(args);
+          return {
+            content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+          };
+        }
+
+        case "delete_subscriber": {
+          if (!isDeleteSubscriberArgs(args)) {
+            throw new McpError(
+              ErrorCode.InvalidParams,
+              "Invalid arguments for delete_subscriber: provide subscriber_id or (show_id + email)"
+            );
+          }
+          const data = await this.apiClient.deleteSubscriber(args);
+          return {
+            content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+          };
+        }
+
         default:
           throw new McpError(
             ErrorCode.MethodNotFound,
@@ -471,5 +1111,158 @@ export class ToolHandlers {
       }
       throw error;
     }
+  }
+
+  /**
+   * Extract per-day download entries from a Transistor analytics response.
+   * The API returns { data: { attributes: { downloads: [ { date, downloads } ] } } }
+   */
+  private extractDownloads(
+    analyticsData: any
+  ): { date: string; downloads: number }[] {
+    const downloads =
+      analyticsData?.data?.attributes?.downloads ??
+      analyticsData?.data?.attributes?.episodes;
+    if (!Array.isArray(downloads)) return [];
+    return downloads.map((d: any) => ({
+      date: typeof d.date === "string" ? toIsoDate(d.date) : d.date,
+      downloads: Number(d.downloads ?? 0),
+    }));
+  }
+
+  /**
+   * Compute summary stats from a list of daily download entries.
+   */
+  private summarizeDownloads(days: { date: string; downloads: number }[]) {
+    if (days.length === 0) {
+      return {
+        total_downloads: 0,
+        daily_average: 0,
+        days_in_range: 0,
+        best_day: null,
+        worst_day: null,
+        week_over_week_trend: null,
+      };
+    }
+
+    const total = days.reduce((sum, d) => sum + d.downloads, 0);
+    const avg = total / days.length;
+
+    const sorted = [...days].sort((a, b) => b.downloads - a.downloads);
+    const best = sorted[0];
+    const worst = sorted[sorted.length - 1];
+
+    // Week-over-week: compare last 7 days vs previous 7 days
+    let weekOverWeekTrend: {
+      current_week: number;
+      previous_week: number;
+      change_pct: number;
+    } | null = null;
+
+    if (days.length >= 14) {
+      // Sort chronologically before slicing — the API does not guarantee
+      // ordering, and ISO yyyy-mm-dd strings sort lexicographically by date.
+      const byDate = [...days].sort((a, b) => a.date.localeCompare(b.date));
+      const lastWeek = byDate.slice(-7);
+      const prevWeek = byDate.slice(-14, -7);
+      const lastTotal = lastWeek.reduce((s, d) => s + d.downloads, 0);
+      const prevTotal = prevWeek.reduce((s, d) => s + d.downloads, 0);
+      const changePct =
+        prevTotal === 0 ? 0 : ((lastTotal - prevTotal) / prevTotal) * 100;
+      weekOverWeekTrend = {
+        current_week: lastTotal,
+        previous_week: prevTotal,
+        change_pct: Math.round(changePct * 10) / 10,
+      };
+    }
+
+    return {
+      total_downloads: total,
+      daily_average: Math.round(avg * 10) / 10,
+      days_in_range: days.length,
+      best_day: { date: best.date, downloads: best.downloads },
+      worst_day: { date: worst.date, downloads: worst.downloads },
+      week_over_week_trend: weekOverWeekTrend,
+    };
+  }
+
+  private async computeDownloadSummary(args: GetDownloadSummaryArgs) {
+    const analyticsData = await this.apiClient.getAnalytics({
+      show_id: args.show_id,
+      episode_id: args.episode_id,
+      start_date: args.start_date,
+      end_date: args.end_date,
+    });
+
+    const days = this.extractDownloads(analyticsData);
+    return this.summarizeDownloads(days);
+  }
+
+  private async computeEpisodeComparison(args: CompareEpisodesArgs) {
+    const results = await Promise.all(
+      args.episode_ids.map(async (episode_id) => {
+        // Fetch analytics and episode metadata in parallel. Capture failures
+        // per-episode so one bad episode does not abort the whole comparison,
+        // but surface the error instead of silently reporting zero downloads.
+        const [analyticsData, episodeData] = await Promise.all([
+          this.apiClient
+            .getAnalytics({
+              show_id: "_", // show_id is ignored when episode_id is provided
+              episode_id,
+              start_date: args.start_date,
+              end_date: args.end_date,
+            })
+            .catch((e: unknown) => ({ __error: errorMessage(e) })),
+          this.apiClient
+            .getEpisode({ episode_id })
+            .catch(() => null),
+        ]);
+
+        const analyticsError =
+          analyticsData && typeof analyticsData === "object" && "__error" in analyticsData
+            ? (analyticsData as { __error: string }).__error
+            : null;
+        const days = analyticsError
+          ? []
+          : this.extractDownloads(analyticsData);
+        const total = days.reduce((s, d) => s + d.downloads, 0);
+        const avg = days.length > 0 ? total / days.length : 0;
+        const sorted = [...days].sort((a, b) => b.downloads - a.downloads);
+        const peak = sorted.length > 0 ? sorted[0] : null;
+
+        // Compute days since publish
+        const publishedAt =
+          episodeData?.data?.attributes?.published_at ?? null;
+        let daysSincePublish: number | null = null;
+        if (publishedAt) {
+          const pubDate = new Date(publishedAt);
+          const now = new Date();
+          daysSincePublish = Math.floor(
+            (now.getTime() - pubDate.getTime()) / (1000 * 60 * 60 * 24)
+          );
+        }
+
+        const title =
+          episodeData?.data?.attributes?.title ?? `Episode ${episode_id}`;
+
+        return {
+          episode_id,
+          title,
+          total_downloads: total,
+          daily_average: Math.round(avg * 10) / 10,
+          peak_day: peak
+            ? { date: peak.date, downloads: peak.downloads }
+            : null,
+          days_in_range: days.length,
+          days_since_publish: daysSincePublish,
+          ...(analyticsError ? { error: analyticsError } : {}),
+        };
+      })
+    );
+
+    // Sort by total downloads descending
+    results.sort((a, b) => b.total_downloads - a.total_downloads);
+
+    return { episodes: results };
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,28 +3,45 @@ export interface GetAuthenticatedUserArgs {
 }
 
 export interface AuthorizeUploadArgs {
-  filename: string;  // Required: Filename of the audio file to upload
+  filename: string;
 }
 
 export interface ListShowsArgs {
   page?: number;
+  per?: number;
+  private?: boolean;
+  query?: string;
 }
 
 export interface ListEpisodesArgs {
   show_id: string;
   page?: number;
+  per?: number;
+  query?: string;
   status?: "published" | "draft" | "scheduled";
+  order?: "asc" | "desc";
+  fields?: { [key: string]: string[] };
 }
 
 export interface CreateEpisodeArgs {
   show_id: string;
   title: string;
+  audio_url: string;
   summary?: string;
   description?: string;
-  status?: "published" | "draft" | "scheduled";
+  transcript_text?: string;
+  author?: string;
+  explicit?: boolean;
+  image_url?: string;
+  keywords?: string;
+  number?: number;
   season_number?: number;
-  episode_number?: number;
-  audio_url: string;
+  type?: "full" | "trailer" | "bonus";
+  alternate_url?: string;
+  video_url?: string;
+  email_notifications?: boolean;
+  increment_number?: boolean;
+  status?: "published" | "draft" | "scheduled";
 }
 
 export interface UpdateEpisodeArgs {
@@ -32,22 +49,32 @@ export interface UpdateEpisodeArgs {
   title?: string;
   summary?: string;
   description?: string;
-  status?: "published" | "draft" | "scheduled";
+  transcript_text?: string;
+  author?: string;
+  explicit?: boolean;
+  image_url?: string;
+  keywords?: string;
+  number?: number;
   season_number?: number;
   episode_number?: number;
+  type?: "full" | "trailer" | "bonus";
+  alternate_url?: string;
+  video_url?: string;
+  email_notifications?: boolean;
+  status?: "published" | "draft" | "scheduled";
 }
 
 export interface GetAnalyticsArgs {
   show_id: string;
   episode_id?: string;
-  start_date: string;
-  end_date: string;
+  start_date?: string;
+  end_date?: string;
 }
 
 export interface GetAllEpisodeAnalyticsArgs {
   show_id: string;
-  start_date: string;
-  end_date: string;
+  start_date?: string;
+  end_date?: string;
 }
 
 export interface ListWebhooksArgs {
@@ -55,7 +82,7 @@ export interface ListWebhooksArgs {
 }
 
 export interface SubscribeWebhookArgs {
-  event_name: string;  // "episode_created"
+  event_name: string;
   show_id: string;
   url: string;
 }
@@ -70,69 +97,123 @@ export interface GetEpisodeArgs {
   fields?: { [key: string]: string[] };
 }
 
+export interface GetDownloadSummaryArgs {
+  show_id: string;
+  episode_id?: string;
+  start_date?: string;
+  end_date?: string;
+}
+
+export interface CompareEpisodesArgs {
+  episode_ids: string[];
+  start_date?: string;
+  end_date?: string;
+}
+
+export interface PublishEpisodeArgs {
+  episode_id: string;
+  status: "published" | "scheduled" | "draft";
+  published_at?: string;
+}
+
+export interface GetShowArgs {
+  show_id: string;
+}
+
+export interface UpdateShowArgs {
+  show_id: string;
+  author?: string;
+  category?: string;
+  copyright?: string;
+  description?: string;
+  explicit?: boolean;
+  image_url?: string;
+  keywords?: string;
+  language?: string;
+  owner_email?: string;
+  secondary_category?: string;
+  show_type?: "episodic" | "serial";
+  title?: string;
+  time_zone?: string;
+  website?: string;
+}
+
+export interface ListSubscribersArgs {
+  show_id: string;
+  page?: number;
+  per?: number;
+  query?: string;
+}
+
+export interface GetSubscriberArgs {
+  subscriber_id: string;
+}
+
+export interface CreateSubscriberArgs {
+  show_id: string;
+  email: string;
+  skip_welcome_email?: boolean;
+}
+
+export interface CreateSubscribersBatchArgs {
+  show_id: string;
+  emails: string[];
+  skip_welcome_email?: boolean;
+}
+
+export interface UpdateSubscriberArgs {
+  subscriber_id: string;
+  email: string;
+}
+
+export interface DeleteSubscriberArgs {
+  subscriber_id?: string;
+  show_id?: string;
+  email?: string;
+}
+
+// --- Validators ---
+
 export function isListShowsArgs(args: unknown): args is ListShowsArgs {
   if (!args || typeof args !== "object") return false;
-  const { page } = args as ListShowsArgs;
-  return page === undefined || typeof page === "number";
+  const { page, per, query } = args as ListShowsArgs;
+  return (
+    (page === undefined || typeof page === "number") &&
+    (per === undefined || typeof per === "number") &&
+    (query === undefined || typeof query === "string")
+  );
 }
 
 export function isListEpisodesArgs(args: unknown): args is ListEpisodesArgs {
   if (!args || typeof args !== "object") return false;
-  const { show_id, page, status } = args as ListEpisodesArgs;
+  const { show_id, page, per, query, status, order, fields } =
+    args as ListEpisodesArgs;
   return (
     typeof show_id === "string" &&
     (page === undefined || typeof page === "number") &&
+    (per === undefined || typeof per === "number") &&
+    (query === undefined || typeof query === "string") &&
     (status === undefined ||
-      ["published", "draft", "scheduled"].includes(status))
+      ["published", "draft", "scheduled"].includes(status)) &&
+    (order === undefined || ["asc", "desc"].includes(order)) &&
+    (fields === undefined || typeof fields === "object")
   );
 }
 
 export function isCreateEpisodeArgs(args: unknown): args is CreateEpisodeArgs {
   if (!args || typeof args !== "object") return false;
-  const {
-    show_id,
-    title,
-    audio_url,
-    summary,
-    description,
-    status,
-    season_number,
-    episode_number,
-  } = args as CreateEpisodeArgs;
+  const { show_id, title, audio_url } = args as CreateEpisodeArgs;
   return (
     typeof show_id === "string" &&
     typeof title === "string" &&
-    typeof audio_url === "string" &&
-    (summary === undefined || typeof summary === "string") &&
-    (description === undefined || typeof description === "string") &&
-    (status === undefined ||
-      ["published", "draft", "scheduled"].includes(status)) &&
-    (season_number === undefined || typeof season_number === "number") &&
-    (episode_number === undefined || typeof episode_number === "number")
+    typeof audio_url === "string"
   );
 }
 
 export function isUpdateEpisodeArgs(args: unknown): args is UpdateEpisodeArgs {
   if (!args || typeof args !== "object") return false;
-  const {
-    episode_id,
-    title,
-    summary,
-    description,
-    status,
-    season_number,
-    episode_number,
-  } = args as UpdateEpisodeArgs;
-  return (
-    typeof episode_id === "string" &&
-    (title === undefined || typeof title === "string") &&
-    (summary === undefined || typeof summary === "string") &&
-    (description === undefined || typeof description === "string") &&
-    (status === undefined ||
-      ["published", "draft", "scheduled"].includes(status)) &&
-    (season_number === undefined || typeof season_number === "number") &&
-    (episode_number === undefined || typeof episode_number === "number")
-  );
+  const { episode_id } = args as UpdateEpisodeArgs;
+  return typeof episode_id === "string";
 }
 
 export function isGetAnalyticsArgs(args: unknown): args is GetAnalyticsArgs {
@@ -142,18 +223,21 @@ export function isGetAnalyticsArgs(args: unknown): args is GetAnalyticsArgs {
   return (
     typeof show_id === "string" &&
     (episode_id === undefined || typeof episode_id === "string") &&
-    typeof start_date === "string" &&
-    typeof end_date === "string"
+    (start_date === undefined || typeof start_date === "string") &&
+    (end_date === undefined || typeof end_date === "string")
   );
 }
 
-export function isGetAllEpisodeAnalyticsArgs(args: unknown): args is GetAllEpisodeAnalyticsArgs {
+export function isGetAllEpisodeAnalyticsArgs(
+  args: unknown
+): args is GetAllEpisodeAnalyticsArgs {
   if (!args || typeof args !== "object") return false;
-  const { show_id, start_date, end_date } = args as GetAllEpisodeAnalyticsArgs;
+  const { show_id, start_date, end_date } =
+    args as GetAllEpisodeAnalyticsArgs;
   return (
     typeof show_id === "string" &&
-    typeof start_date === "string" &&
-    typeof end_date === "string"
+    (start_date === undefined || typeof start_date === "string") &&
+    (end_date === undefined || typeof end_date === "string")
   );
 }
 
@@ -163,7 +247,9 @@ export function isListWebhooksArgs(args: unknown): args is ListWebhooksArgs {
   return typeof show_id === "string";
 }
 
-export function isSubscribeWebhookArgs(args: unknown): args is SubscribeWebhookArgs {
+export function isSubscribeWebhookArgs(
+  args: unknown
+): args is SubscribeWebhookArgs {
   if (!args || typeof args !== "object") return false;
   const { event_name, show_id, url } = args as SubscribeWebhookArgs;
   return (
@@ -173,18 +259,23 @@ export function isSubscribeWebhookArgs(args: unknown): args is SubscribeWebhookA
   );
 }
 
-export function isUnsubscribeWebhookArgs(args: unknown): args is UnsubscribeWebhookArgs {
+export function isUnsubscribeWebhookArgs(
+  args: unknown
+): args is UnsubscribeWebhookArgs {
   if (!args || typeof args !== "object") return false;
   const { webhook_id } = args as UnsubscribeWebhookArgs;
   return typeof webhook_id === "string";
 }
 
-export function isGetAuthenticatedUserArgs(args: unknown): args is GetAuthenticatedUserArgs {
-  // No arguments to validate
+export function isGetAuthenticatedUserArgs(
+  args: unknown
+): args is GetAuthenticatedUserArgs {
   return true;
 }
 
-export function isAuthorizeUploadArgs(args: unknown): args is AuthorizeUploadArgs {
+export function isAuthorizeUploadArgs(
+  args: unknown
+): args is AuthorizeUploadArgs {
   if (!args || typeof args !== "object") return false;
   const { filename } = args as AuthorizeUploadArgs;
   return typeof filename === "string";
@@ -197,5 +288,112 @@ export function isGetEpisodeArgs(args: unknown): args is GetEpisodeArgs {
     typeof episode_id === "string" &&
     (include === undefined || Array.isArray(include)) &&
     (fields === undefined || typeof fields === "object")
+  );
+}
+
+export function isGetDownloadSummaryArgs(
+  args: unknown
+): args is GetDownloadSummaryArgs {
+  if (!args || typeof args !== "object") return false;
+  const { show_id, episode_id, start_date, end_date } =
+    args as GetDownloadSummaryArgs;
+  return (
+    typeof show_id === "string" &&
+    (episode_id === undefined || typeof episode_id === "string") &&
+    (start_date === undefined || typeof start_date === "string") &&
+    (end_date === undefined || typeof end_date === "string")
+  );
+}
+
+export function isCompareEpisodesArgs(
+  args: unknown
+): args is CompareEpisodesArgs {
+  if (!args || typeof args !== "object") return false;
+  const { episode_ids, start_date, end_date } = args as CompareEpisodesArgs;
+  return (
+    Array.isArray(episode_ids) &&
+    episode_ids.length >= 2 &&
+    episode_ids.every((id: unknown) => typeof id === "string") &&
+    (start_date === undefined || typeof start_date === "string") &&
+    (end_date === undefined || typeof end_date === "string")
+  );
+}
+
+export function isPublishEpisodeArgs(
+  args: unknown
+): args is PublishEpisodeArgs {
+  if (!args || typeof args !== "object") return false;
+  const { episode_id, status } = args as PublishEpisodeArgs;
+  return (
+    typeof episode_id === "string" &&
+    ["published", "scheduled", "draft"].includes(status)
+  );
+}
+
+export function isGetShowArgs(args: unknown): args is GetShowArgs {
+  if (!args || typeof args !== "object") return false;
+  const { show_id } = args as GetShowArgs;
+  return typeof show_id === "string";
+}
+
+export function isUpdateShowArgs(args: unknown): args is UpdateShowArgs {
+  if (!args || typeof args !== "object") return false;
+  const { show_id } = args as UpdateShowArgs;
+  return typeof show_id === "string";
+}
+
+export function isListSubscribersArgs(
+  args: unknown
+): args is ListSubscribersArgs {
+  if (!args || typeof args !== "object") return false;
+  const { show_id } = args as ListSubscribersArgs;
+  return typeof show_id === "string";
+}
+
+export function isGetSubscriberArgs(
+  args: unknown
+): args is GetSubscriberArgs {
+  if (!args || typeof args !== "object") return false;
+  const { subscriber_id } = args as GetSubscriberArgs;
+  return typeof subscriber_id === "string";
+}
+
+export function isCreateSubscriberArgs(
+  args: unknown
+): args is CreateSubscriberArgs {
+  if (!args || typeof args !== "object") return false;
+  const { show_id, email } = args as CreateSubscriberArgs;
+  return typeof show_id === "string" && typeof email === "string";
+}
+
+export function isCreateSubscribersBatchArgs(
+  args: unknown
+): args is CreateSubscribersBatchArgs {
+  if (!args || typeof args !== "object") return false;
+  const { show_id, emails } = args as CreateSubscribersBatchArgs;
+  return (
+    typeof show_id === "string" &&
+    Array.isArray(emails) &&
+    emails.every((e: unknown) => typeof e === "string")
+  );
+}
+
+export function isUpdateSubscriberArgs(
+  args: unknown
+): args is UpdateSubscriberArgs {
+  if (!args || typeof args !== "object") return false;
+  const { subscriber_id, email } = args as UpdateSubscriberArgs;
+  return typeof subscriber_id === "string" && typeof email === "string";
+}
+
+export function isDeleteSubscriberArgs(
+  args: unknown
+): args is DeleteSubscriberArgs {
+  if (!args || typeof args !== "object") return false;
+  const { subscriber_id, show_id, email } = args as DeleteSubscriberArgs;
+  // Either subscriber_id OR (show_id + email) must be provided
+  return (
+    typeof subscriber_id === "string" ||
+    (typeof show_id === "string" && typeof email === "string")
   );
 }


### PR DESCRIPTION
Integrates the code improvements from the [conorbronsdon fork](https://github.com/conorbronsdon/Transistor-MCP) on top of this repo, keeping our own package identity and dropping the fork's registry/branding files (`glama.json`, `server.json`, repo-pointer rewrites in `package.json`).

## New capabilities
- **Subscriber management:** `list_subscribers`, `get_subscriber`, `create_subscriber`, `create_subscribers_batch`, `update_subscriber`, `delete_subscriber`
- **Show management:** `get_show`, `update_show`
- **`publish_episode`** — change status (published/scheduled/draft) without editing other metadata
- **Analytics helpers:** `get_download_summary` (totals, daily average, week-over-week trend, best/worst day) and `compare_episodes`
- **Richer episode fields:** `transcript_text`, `author`, `explicit`, `keywords`, `type`, `video_url`, `alternate_url`, and more
- **Query enhancements:** `per`, `query`, `order`, and sparse fieldsets (`fields`) to trim payloads
- **ISO date input** (`yyyy-mm-dd`), auto-converted to the API's `dd-mm-yyyy`
- **Lazy auth:** server starts without a key and fails per tool call (better for npx/registry listing)
- Minimal production Dockerfile

## Hardening applied on top of the merged code
- Validate ISO dates against the calendar before sending (reject `2025-13-40`)
- Guard `delete_subscriber`: require `subscriber_id`, or both `show_id` and `email`
- Sort downloads chronologically before week-over-week slicing (API order not guaranteed)
- Surface per-episode analytics errors in `compare_episodes` instead of silently reporting zero downloads

## Verification
- `npm run build` clean, 0 TypeScript errors
- Server starts without `TRANSISTOR_API_KEY` (lazy-auth warning, no crash)
- Subscriber create/update request shapes verified against the Transistor API docs (update uses the `subscriber[email]` wrapper; create/batch/delete are flat)

## Attribution
Original work by Guido X Jansen; merged improvements by Conor Bronsdon (credited as contributor in `package.json`).

## Not included
- npm publish: the `transistor-mcp` name is already taken on npm by the fork author; this repo stays `private` for now. Publishing later would need a scoped name (`@gxjansen/transistor-mcp`) or coordination.
- SDK/axios dependency bumps (open dependabot PRs) — left for a separate change.